### PR TITLE
Add default dashboard for CPU Core

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,6 +5,12 @@
   "unsupportedPlatforms" : [ ],
   "tags" : "cpu,core",
   "description" : "Provides per core CPU utilization",
+  "dashboards" : [
+                 {
+                 "name" : "CPU Core",
+                 "layout" : "d-w=1&d-h=1&d-pad=5&d-bg=none&d-g-CPU_CORE=0-0-1-1"
+                 }
+  ],
   "command" : "node index.js $(pollInterval)",
   "command_lua" : "boundary-meter init.lua",
   "postExtract" : "npm install",


### PR DESCRIPTION
- Reviewed with Customer Success team and they are firm advocates of having at least one default dashboard for every plugin.
