### PR TITLE
Use - to be backward compatible with the NodeJS version of sources

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -32,7 +32,7 @@ function plugin:onParseValues(data)
   each(function (v, i) 
     local metric, cpu_id = v.metric:match('^(system%.cpu%.usage)|cpu=(%d+)$')
     if metric then
-      table.insert(result, pack('CPU_CORE', v.value, v.timestamp, plugin.source .. '_C' .. cpu_id))
+      table.insert(result, pack('CPU_CORE', v.value, v.timestamp, plugin.source .. '-C' .. cpu_id))
     end
   end, data)
 


### PR DESCRIPTION
The NodeJS version of the CPU core plugin used the base source name (provided by the user or default is the hostname) and a '-' to between the CPU instance. The lua plugin version was using an underscore '_'.
